### PR TITLE
Bug Fix - Current weather info fails to load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -125,6 +125,7 @@ function currentweather(lat, lon){
         "&appid=" +
         process.env.REACT_APP_APIKEY
     )
+    .then(result => result.json())
       .then(
         (result) => {
           if (result["cod"] !== 200) {


### PR DESCRIPTION
Someone had accidentally deleted `.then(result => result.json())` from the useEffect hook. This should solve the issue where the weather info fails to load.